### PR TITLE
Problem in IE when there is a global width applied to textareas

### DIFF
--- a/jquery.getscrollbarwidth.js
+++ b/jquery.getscrollbarwidth.js
@@ -12,9 +12,9 @@
 		if ( !scrollbarWidth ) {
 			if ( $.browser.msie ) {
 				var $textarea1 = $('<textarea cols="10" rows="2"></textarea>')
-						.css({ position: 'absolute', top: -1000, left: -1000 }).appendTo('body'),
+						.css({ position: 'absolute', top: -1000, left: -1000, width: 'auto' }).appendTo('body'),
 					$textarea2 = $('<textarea cols="10" rows="2" style="overflow: hidden;"></textarea>')
-						.css({ position: 'absolute', top: -1000, left: -1000 }).appendTo('body');
+						.css({ position: 'absolute', top: -1000, left: -1000, width: 'auto' }).appendTo('body');
 				scrollbarWidth = $textarea1.width() - $textarea2.width();
 				$textarea1.add($textarea2).remove();
 			} else {


### PR DESCRIPTION
I ran into a problem with this handy plugin when IE would be returning 0 for the scrollbar width.

It turned out that the problem was caused by a global CSS rule giving textareas a fixed width, which made this plugin return wrong results in IE.

Setting width to "auto" on the generated textareas fixes the problem.
